### PR TITLE
feat: Add auto-focus to input fields on repository and conversation pages

### DIFF
--- a/resources/js/pages/Claude.vue
+++ b/resources/js/pages/Claude.vue
@@ -652,6 +652,8 @@ onMounted(async () => {
         await scrollToBottom(true);
         // Also refresh conversations to ensure sidebar is up to date
         await fetchConversations(true, true);
+        // Focus input after loading conversation
+        focusInput(false);
     } else if (props.conversationId) {
         // For conversation-based pages, we'll need to wait for the session file
         // Start polling immediately to check for session file
@@ -664,8 +666,10 @@ onMounted(async () => {
         messages.value = [];
         sessionFilename.value = null;
         sessionId.value = null;
-        focusInput(false);
     }
+    
+    // Auto-focus input on mount
+    focusInput(false);
 });
 
 onUnmounted(() => {

--- a/resources/js/pages/RepositoryDashboard.vue
+++ b/resources/js/pages/RepositoryDashboard.vue
@@ -67,6 +67,11 @@ const quickMessages = [
 
 onMounted(() => {
     fetchFileTree();
+    // Auto-focus the input when page loads
+    const inputEl = document.querySelector('input[placeholder="Type your message or question..."]') as HTMLInputElement;
+    if (inputEl) {
+        inputEl.focus();
+    }
 });
 </script>
 


### PR DESCRIPTION
## Summary
- Auto-focus input field when entering repository dashboard page
- Auto-focus textarea when entering conversation page  
- Auto-focus textarea when loading existing conversations

## Description
This PR improves user experience by automatically focusing the input fields when users navigate to the repository dashboard or conversation pages. Users can start typing immediately without needing to manually click on the input field first.

### Changes made:
1. **Repository Dashboard**: Added auto-focus to the message input field on mount
2. **Conversation Page (Claude.vue)**: 
   - Added auto-focus when page loads
   - Added auto-focus when loading existing conversations
   - Ensures input is always ready for user interaction

## Test plan
- [ ] Navigate to repository dashboard page - input should be focused automatically
- [ ] Navigate to conversation page - textarea should be focused automatically
- [ ] Open an existing conversation - textarea should be focused after loading
- [ ] Create a new conversation - textarea should remain focused

🤖 Generated with [Claude Code](https://claude.ai/code)