### PR TITLE
fix: Add delay before setting is_processing to false

### DIFF
--- a/app/Jobs/SendClaudeMessageJob.php
+++ b/app/Jobs/SendClaudeMessageJob.php
@@ -116,6 +116,10 @@ class SendClaudeMessageJob implements ShouldQueue
 
             // Filename is already set at the beginning, no need to update it again
             
+            // Add a small delay to ensure the file has been completely written
+            // This prevents the frontend from seeing is_processing = false before the response is ready
+            sleep(1);
+            
             // Mark conversation as no longer processing
             $this->conversation->update(['is_processing' => false]);
 


### PR DESCRIPTION
## Summary
- Added a 1-second delay before setting `is_processing` to false in SendClaudeMessageJob
- Ensures the response file is fully written before marking conversation as complete
- Prevents frontend from showing conversation as finished before the final response is available

## Problem
The `is_processing` flag was being set to false immediately after the Claude process completed, but before the file system had time to fully write and flush the response. This caused a race condition where the frontend would see the conversation as complete before the final response was actually available to read.

## Solution
Added a small delay (1 second) after the Claude process completes and before updating `is_processing` to false. This gives the file system time to:
- Complete any pending write operations
- Flush buffers to disk
- Make the response available for the frontend to read

## Test plan
- [ ] Send a message to Claude
- [ ] Verify that `is_processing` remains true until the response is fully written
- [ ] Confirm the frontend displays the complete response when `is_processing` becomes false
- [ ] Test with both short and long Claude responses

🤖 Generated with [Claude Code](https://claude.ai/code)